### PR TITLE
Adds support for adding a textdomain from an already parsed json object

### DIFF
--- a/lib/gettext.js
+++ b/lib/gettext.js
@@ -26,7 +26,10 @@ Gettext.prototype.addTextdomain = function(domain, file) {
     domain = this._normalizeDomain(domain);
     var translation;
 
-    if (file && typeof file !== 'string') {
+    if (file && file.translations) {
+        translation = file;
+    }
+    else if (file && typeof file !== 'string') {
         translation = gettextParser.mo.parse(file, 'utf-8');
     }
 

--- a/test/fixtures/latin13.json
+++ b/test/fixtures/latin13.json
@@ -1,0 +1,100 @@
+{
+  "charset": "iso-8859-13",
+  "headers": {
+    "project-id-version": "gettext-parser",
+    "report-msgid-bugs-to": "andris@node.ee",
+    "pot-creation-date": "2012-05-18 14:28:00+03:00",
+    "po-revision-date": "2012-05-18 14:44+0300",
+    "last-translator": "Andris Reinman <andris@kreata.ee>",
+    "language-team": "gettext-parser <andris@node.ee>",
+    "mime-version": "1.0",
+    "content-type": "text/plain; charset=iso-8859-13",
+    "content-transfer-encoding": "8bit",
+    "language": "",
+    "plural-forms": "nplurals=2; plural=(n!=1);",
+    "x-poedit-language": "Estonian",
+    "x-poedit-country": "ESTONIA",
+    "x-poedit-sourcecharset": "iso-8859-13"
+  },
+  "translations": {
+    "": {
+      "": {
+        "msgid": "",
+        "comments": {
+          "translator": "gettext-parser test file.\nCopyright (C) 2012 Andris Reinman\nThis file is distributed under the same license as the gettext-parser package.\nANDRIS REINMAN <andris@node.ee>, 2012.\n"
+        },
+        "msgstr": [
+          "Project-Id-Version: gettext-parser\nReport-Msgid-Bugs-To: andris@node.ee\nPOT-Creation-Date: 2012-05-18 14:28:00+03:00\nPO-Revision-Date: 2012-05-18 14:44+0300\nLast-Translator: Andris Reinman <andris@kreata.ee>\nLanguage-Team: gettext-parser <andris@node.ee>\nMIME-Version: 1.0\nContent-Type: text/plain; charset=iso-8859-13\nContent-Transfer-Encoding: 8bit\nLanguage: \nPlural-Forms: nplurals=2; plural=(n!=1);\nX-Poedit-Language: Estonian\nX-Poedit-Country: ESTONIA\nX-Poedit-Sourcecharset: iso-8859-13\n"
+        ]
+      },
+      "o1": {
+        "msgid": "o1",
+        "comments": {
+          "translator": "Normal string"
+        },
+        "msgstr": [
+          "t1"
+        ]
+      },
+      "o2-1": {
+        "msgid": "o2-1",
+        "comments": {
+          "translator": "Plural string"
+        },
+        "msgid_plural": "o2-2",
+        "msgstr": [
+          "t2-1",
+          "t2-2"
+        ]
+      },
+      "o3-ĆµĆ¤Ć¶Ć¼": {
+        "msgid": "o3-ĆµĆ¤Ć¶Ć¼",
+        "comments": {
+          "translator": "Normal string with special chars"
+        },
+        "msgstr": [
+          "t3-Ć¾Ć°"
+        ]
+      },
+      "test": {
+        "msgid": "test",
+        "comments": {
+          "translator": "Normal comment line 1\nNormal comment line 2",
+          "extracted": "Editors note line 1\nEditors note line 2",
+          "reference": "/absolute/path:13\n/absolute/path:14",
+          "flag": "line 1\nline 2",
+          "previous": "line 3\nline 4"
+        },
+        "msgstr": [
+          "test"
+        ]
+      }
+    },
+    "c1": {
+      "co1": {
+        "msgid": "co1",
+        "msgctxt": "c1",
+        "comments": {
+          "translator": "Normal string in a context"
+        },
+        "msgstr": [
+          "ct1"
+        ]
+      }
+    },
+    "c2": {
+      "co2-1": {
+        "msgid": "co2-1",
+        "msgctxt": "c2",
+        "comments": {
+          "translator": "Plural string in a context"
+        },
+        "msgid_plural": "co2-2",
+        "msgstr": [
+          "ct2-1",
+          "ct2-2"
+        ]
+      }
+    }
+  }
+}

--- a/test/gettext-test.js
+++ b/test/gettext-test.js
@@ -40,6 +40,16 @@ describe('Gettext', function() {
             expect(gt.domains.et_EE.charset).to.equal('iso-8859-13');
         });
 
+        it('Should add from a json file', function() {
+            var gt = new Gettext();
+            var jsonFile = JSON.parse(fs.readFileSync(__dirname + '/fixtures/latin13.json'));
+
+            gt.addTextdomain('et-EE', jsonFile);
+
+            expect(gt.domains.et_EE).to.exist;
+            expect(gt.domains.et_EE.charset).to.equal('iso-8859-13');
+        });
+
     });
 
     describe('#textdomain', function() {


### PR DESCRIPTION
Hi!

I have crossed the land and walked through fire for a plain gettext JavaScript library that accepts standardized JSON translation objects, but to no avail. So I checked the source and realized what a small change be needed for this excellent lib to support this.

The case is I want to use standardized gettext that's populated with translations at runtime in the browser, without doing HTTP requests to .po files (i.e. the translations are bundled in the JavaScript file).

- Do you think this goes against the purpose of this library?
- Is the truthiness of `file.translations` a stable enough check for an already parsed JSON object?

If not, yay! If so, I'll make a new npm package that simply extends this one with that simple check.